### PR TITLE
Upgrades all the gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'puma'
 gem 'redis-namespace'
-gem 'sidekiq'
+gem 'sidekiq', '~> 6.1.0' # 6.2 breaks Rack sessions
 gem 'sidekiq-scheduler'
 gem 'sidekiq-status'
 gem 'tzinfo-data'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,59 +3,57 @@ GEM
   specs:
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
-    concurrent-ruby (1.1.6)
-    connection_pool (2.2.3)
+    concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     e2mmap (0.1.0)
-    et-orbi (1.2.4)
+    et-orbi (1.2.6)
       tzinfo
-    fugit (1.3.6)
+    fugit (1.5.2)
       et-orbi (~> 1.1, >= 1.1.8)
-      raabro (~> 1.3)
-    nio4r (2.5.2)
+      raabro (~> 1.4)
+    nio4r (2.5.8)
     numerizer (0.1.1)
-    puma (4.3.5)
+    puma (5.5.2)
       nio4r (~> 2.0)
-    raabro (1.3.1)
+    raabro (1.4.0)
     rack (2.2.3)
-    rack-protection (2.0.8.1)
-      rack
-    redis (4.2.1)
-    redis-namespace (1.7.0)
+    redis (4.5.1)
+    redis-namespace (1.8.1)
       redis (>= 3.0.4)
-    rufus-scheduler (3.6.0)
+    rufus-scheduler (3.8.0)
       fugit (~> 1.1, >= 1.1.6)
-    sidekiq (6.0.7)
+    sidekiq (6.1.3)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
-    sidekiq-scheduler (3.0.1)
+      redis (>= 4.2.0)
+    sidekiq-scheduler (3.1.0)
       e2mmap
       redis (>= 3, < 5)
       rufus-scheduler (~> 3.2)
       sidekiq (>= 3)
       thwait
       tilt (>= 1.4.0)
-    sidekiq-status (1.1.4)
+    sidekiq-status (2.1.0)
       chronic_duration
-      sidekiq (>= 3.0)
-    thwait (0.1.0)
+      sidekiq (>= 5.0)
+    thwait (0.2.0)
+      e2mmap
     tilt (2.0.10)
-    tzinfo (2.0.2)
+    tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2020.1)
+    tzinfo-data (1.2021.5)
       tzinfo (>= 1.0.0)
 
 PLATFORMS
-  ruby
+  x86_64-linux-musl
 
 DEPENDENCIES
   puma
   redis-namespace
-  sidekiq
+  sidekiq (~> 6.1.0)
   sidekiq-scheduler
   sidekiq-status
   tzinfo-data
 
 BUNDLED WITH
-   2.1.4
+   2.2.31


### PR DESCRIPTION
This commit upgrade all the gems, especially the `redis-namespace` gem to version 1.8.1 which fixes the compatibility with Ruby 3.

Also this commit limits the version of `sidekiq` in order to keep the puma's config working.